### PR TITLE
New docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN npm run build
 
 # Serve dist
 
-FROM caddy:2.0.0-rc.3-alpine
+FROM caddy:2.0.0-alpine
 ENV ENABLE_TELEMETRY="false"
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,7 @@ RUN npm run build
 
 FROM caddy:2.0.0-rc.3-alpine
 ENV ENABLE_TELEMETRY="false"
-RUN mkdir -p /app/
+
+WORKDIR /app
+COPY configs/certs/ /app/certs/
 COPY --from=0 /app/dist /app/dist

--- a/README.md
+++ b/README.md
@@ -2,22 +2,76 @@
 ion web app
 
 ### Docker
-Build docker image with production build of web app. Serve on `http://:8080`
+Build docker image with production build of web app. Serve on `https://localhost:9090`
+
+Biz websocket is proxied using caddy server and docker network from ion.
 
 ```
 docker-compose up --build
 ```
 
 
+#### Remote Hosting / Auto SSL
+
+Enable production ports and Caddy file for web service in `docker-compose.yml`.
+
+Make sure these ports are exposed publicly
+```
+80/tcp
+443/tcp
+```
+
+Configure your domain.
+
+```
+export WWW_URL=yourdomain
+export ADMIN_EMAIL=yourname@yourdomain
+```
+
+These variables can also be set in the `docker-compose.yml`.
+
+
+#### Chat!
+
+Bring up docker with
+```
+docker-compose up --build
+```
+
+Open this url with chrome
+
+```
+https://yourdomain
+```
+
+
 ### Local Dev
+
 #### Setup
 Install node modules
 ```
 npm i
 ```
+For node dev server the client must be modified for the biz socket.
 
-#### Running
+Edit `App.jsx` and update client config
+
+Change
+```
+new Client({url: "wss://" + window.location.host});
+```
+
+To
+
+```
+new Client({url: "ws://localhost:8443"});
+```
+
+
+#### Run
 Start dev server
 ```
 npm start
 ```
+
+Serves on `https://localhost:8080`

--- a/configs/caddy/Caddyfile
+++ b/configs/caddy/Caddyfile
@@ -1,5 +1,5 @@
 {$WWW_URL} {
-  root * /app/demo/dist
+  root * /app/dist
   file_server
   tls {$ADMIN_EMAIL}
 

--- a/configs/caddy/local.Caddyfile
+++ b/configs/caddy/local.Caddyfile
@@ -1,4 +1,10 @@
-http://localhost:8080 {
+localhost:9090 {
   root * /app/dist
   file_server
+
+  tls /app/certs/cert.pem /app/certs/key.pem
+
+  reverse_proxy /ws biz:8443 {
+    header_up Sec-WebSocket-Protocol {>Sec-WebSocket-Protocol}
+  }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build: .
     volumes:
       # Uncomment for production
-      # - "./docker/Caddyfile:/etc/caddy/Caddyfile"
+      # - "./configs/caddy/Caddyfile:/etc/caddy/Caddyfile"
       # Dev caddyfile
       - "./configs/caddy/local.Caddyfile:/etc/caddy/Caddyfile"
       - "caddy:/root/.caddy/"
@@ -13,10 +13,17 @@ services:
       # Prod ports
       # - 80:80
       # - 443:443
-      - 8080:8080
+      - 9090:9090
+    networks:
+      - ionnet
     environment:
     - WWW_URL
     - ADMIN_EMAIL
 
 volumes:
   caddy:
+
+networks:
+  ionnet:
+    external: true
+    name: ionnet

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -43,7 +43,7 @@ class App extends React.Component {
       codec: "vp8"
     }
 
-    let client = new Client({url: "ws://localhost:8443"});
+    let client = new Client({url: "wss://" + window.location.host});
 
     let settings = reactLocalStorage.getObject("settings");
     if ( settings.codec !== undefined ){


### PR DESCRIPTION
Update docker hosting to use external docker network in order to reach biz service in caddy proxy.

Provide proxy to biz for both insecure local docker mode, and auto ssl prod mode.

Change default client url, leave notes for dev. This could use a better long term solution.