### PR TITLE
Add docker network create command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Build docker image with production build of web app. Serve on `https://localhost
 Biz websocket is proxied using caddy server and docker network from ion.
 
 ```
+docker network create ionnet
 docker-compose up --build
 ```
 


### PR DESCRIPTION
Without it, I get this error:
```
ERROR: Network ionnet declared as external, but could not be found. Please create the network manually using `docker network create ionnet` and try again.
```
