### PR TITLE
Adding connection info test widget

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -66,9 +66,7 @@ class App extends React.Component {
     });
   };
 
-  _handleJoin = async values => {
-    this.setState({ loading: true });
-
+  _createClient = () => {
     let url = "wss://" + window.location.host;
     //for dev by scripts
     if(process.env.NODE_ENV == "development"){
@@ -76,8 +74,16 @@ class App extends React.Component {
       url = proto + "://" + window.location.host;
     }
 
-    console.log("WS url is:" + url);
     let client = new Client({url: url});
+    client.url = url;
+
+    return client
+  }
+
+  _handleJoin = async values => {
+    this.setState({ loading: true });
+
+    let client = this._createClient();
 
     window.onunload = async () => {
       await this._cleanUp();
@@ -429,7 +435,7 @@ class App extends React.Component {
             <Spin size="large" tip="Connecting..." />
           ) : (
                 <Card title="Join to Ion" className="app-login-card">
-                  <LoginForm handleLogin={this._handleJoin} />
+                  <LoginForm handleLogin={this._handleJoin} createClient={this._createClient} />
                 </Card>
               )}
         </Content>

--- a/src/LoginForm.jsx
+++ b/src/LoginForm.jsx
@@ -104,8 +104,8 @@ class LoginForm extends React.Component {
       'audioOnly': audioOnly,
     });
 
-    setTimeout(this._testConnection, 750);
   };
+
   componentWillUnmount = () => {
     this._cleanup();
   }
@@ -143,12 +143,12 @@ class LoginForm extends React.Component {
       await this._stopMediaStream(this.stream);
       await this.stream.unpublish();
     }
-    await this.client.leave();
-
+    if (this.client)
+      await this.client.leave();
   };
 
   _testConnection = async () => {
-
+    this.setState({test: true})
     this._testStep('biz', 'pending');
     let client = this.props.createClient();
     let testUpdateLoop = null;
@@ -320,10 +320,14 @@ class LoginForm extends React.Component {
           </Form.Item>
         </Form>
         <center>
-          <ConnectionStep step={steps.biz} />
-          <ConnectionStep step={steps.lobby} />
-          <ConnectionStep step={steps.publish} />
-          <ConnectionStep step={steps.subscribe} />
+          {this.state.test ?
+          <>
+            <ConnectionStep step={steps.biz} />
+            <ConnectionStep step={steps.lobby} />
+            <ConnectionStep step={steps.publish} />
+            <ConnectionStep step={steps.subscribe} />
+          </>
+          : <Button onClick={() => this._testConnection()}>Test Connection</Button>}
         </center>
       </>
     );

--- a/src/LoginForm.jsx
+++ b/src/LoginForm.jsx
@@ -1,14 +1,82 @@
 import React from "react";
-import { Form, Icon, Input, Button,Checkbox } from "antd";
+import { Form, Icon, Input, Button, Checkbox, notification, Avatar, Badge, Tooltip } from "antd";
+import { LocalStream } from 'ion-sdk-js';
 import { reactLocalStorage } from "reactjs-localstorage";
 import "../styles/css/login.scss";
 
+import CheckIcon from "mdi-react/CheckIcon";
+import ShuffleIcon from "mdi-react/ShuffleIcon";
+import NetworkIcon from "mdi-react/NetworkIcon";
+import ServerNetworkIcon from "mdi-react/ServerNetworkIcon";
+import GoogleClassroomIcon from "mdi-react/GoogleClassroomIcon";
+import ProgressClockIcon from "mdi-react/ProgressClockIcon";
+import ProgressAlertIcon from "mdi-react/ProgressAlertIcon";
+import ProgressCloseIcon from "mdi-react/ProgressCloseIcon";
+import VideoCheckIcon from "mdi-react/VideoCheckIcon";
+import UploadLockIcon from "mdi-react/UploadLockIcon";
+import SwapVerticalIcon from "mdi-react/SwapVerticalIcon";
+import DownloadLockIcon from "mdi-react/DownloadLockIcon";
+
+
+
+
+const TEST_STEPS = {
+  biz: { title: 'Biz Websocket', icon: <ServerNetworkIcon /> },
+  lobby: { title: 'Joining Test Room', icon: <GoogleClassroomIcon /> },
+  publish: { title: 'Publish', icon: <UploadLockIcon /> },
+  subscribe: { title: 'Subscription', icon: <DownloadLockIcon /> },
+};
+
+const ICONS = {
+  connected: CheckIcon,
+  ok: CheckIcon,
+  pending: ProgressClockIcon,
+  warning: ProgressAlertIcon,
+  "no candidates": ProgressAlertIcon,
+  error: ProgressCloseIcon,
+  joined: CheckIcon,
+  published: CheckIcon,
+  subscribed: CheckIcon,
+};
+
+
+const DEFAULT_STATE = {
+  testing: null,
+  success: null,
+  steps: TEST_STEPS
+};
+const ConnectionStep = ({ step }) => {
+  const color = (
+    step.status === 'pending' ? null :
+      step.status === 'warning' || step.status === 'no candidates' ? 'orange' :
+        step.status === 'error' ? 'red' :
+          'green');
+  const Icon = ICONS[step.status];
+
+  return <div className='test-connection-step'>
+    <Badge count={Icon ? <Icon style={{ color }} /> : null}>
+      <Tooltip title={<>
+        {step.title}
+        {step.status ? ": " + step.status : null}
+        {step.info ? <div>{step.info}</div> : null}
+      </>}
+      >
+        <Avatar shape="square" size="large" icon={step.icon} />
+      </Tooltip>
+    </Badge>
+  </div>;
+};
+
 class LoginForm extends React.Component {
+  state = DEFAULT_STATE;
 
   componentDidMount = () => {
-    const {form} = this.props;
+    const { form } = this.props;
     console.log("window.location:" + window.location);
-    console.log("url:" + window.location.protocol + window.location.host + "  " +  window.location.pathname + window.location.query);
+    console.log("url:" + window.location.protocol + window.location.host + "  " + window.location.pathname + window.location.query);
+
+    console.log('Making test client');
+
 
     let params = this.getRequest();
 
@@ -18,7 +86,7 @@ class LoginForm extends React.Component {
 
     let localStorage = reactLocalStorage.getObject("loginInfo");
 
-    if(localStorage){
+    if (localStorage) {
       roomId = localStorage.roomId;
       displayName = localStorage.displayName;
       audioOnly = localStorage.audioOnly;
@@ -34,7 +102,146 @@ class LoginForm extends React.Component {
       'displayName': displayName,
       'audioOnly': audioOnly,
     });
+
+    setTimeout(this._testConnection, 750);
+  };
+
+  _notification = (message, description) => {
+    notification.info({
+      message: message,
+      description: description,
+      placement: "bottomRight"
+    });
+  };
+
+  _testStep(step, status, info = null) {
+    const prior = this.state.steps[step];
+    this.setState({
+      steps: {
+        ...this.state.steps,
+        [step]: { ...prior, status, info }
+      }
+    });
+    console.log('Test Connection:', step, status, info);
   }
+
+  _stopMediaStream = async (stream) => {
+    let tracks = stream.getTracks();
+    for (let i = 0, len = tracks.length; i < len; i++) {
+      await tracks[i].stop();
+    }
+  };
+
+  _testConnection = async () => {
+
+    this._testStep('biz', 'pending');
+    let client = this.props.createClient();
+    let testUpdateLoop = null;
+
+
+    window.onunload = async () => {
+      if (testUpdateLoop)
+        clearInterval(testUpdateLoop);
+      if (this.stream) {
+        await this._stopMediaStream(this.stream);
+        await this.stream.unpublish();
+      }
+      await this.client.leave();
+
+    };
+
+    client.on("transport-open", async () => {
+      this._testStep('biz', 'connected', client.url);
+      this._testStep('lobby', 'pending');
+      const rid = 'lobby-' + Math.floor(1000000 * Math.random());
+      await this.client.join(rid, { name: 'lobby-user' });
+      this._testStep('lobby', 'joined', 'room id='+rid);
+      const localStream = await LocalStream.getUserMedia({
+        codec: 'VP8',
+        resolution: 'hd',
+        bandwidth: 1024,
+        audio: true,
+        video: true,
+      });
+
+      this._testStep('publish', 'pending');
+
+      const publish = await client.publish(localStream);
+
+      let nominated = null;
+
+      const testConnectionUpdateLoop = () => {
+        updateConnectionStats();
+        const subStatus = this.state.steps.subscribe.status;
+        if (subStatus === 'pending' || subStatus === 'error') {
+          trySubscribe();
+        }
+      };
+      testUpdateLoop = setInterval(testConnectionUpdateLoop, 3000);
+      setTimeout(testConnectionUpdateLoop, 150);
+
+      const trySubscribe = async () => {
+        const mid = client.local.mid;
+        let tracks = {}
+
+        try {
+          for (let track of localStream.getTracks()) {
+            console.log(track)
+            tracks[`${mid} ${track.id}`] = {
+              codec: track.codec,
+              fmtp: "",
+              id: track.id,
+              pt: client.local.transport.rtp[0].payload,
+              type: track.kind,
+            };
+          }
+        } catch (e) { console.log("No tracks yet...")}
+
+        if (!mid) return;
+        client.knownStreams.set(mid, objToStrMap(tracks));
+
+
+        console.log('Trying to subscribe to ...', mid);
+
+        try {
+          let stream = await client.subscribe(mid);
+          this._testStep('subscribe', 'subscribed', 'mid: ' + mid);
+
+        } catch (e) {
+          console.log(e)
+          this._testStep('subscribe', 'error');
+        }
+
+      };
+
+      const updateConnectionStats = async () => {
+        const report = await client.local.transport.pc.getStats();
+        const stats = {};
+        for (let [name, stat] of report) {
+          stats[name] = stat;
+          if (stat.nominated) {
+            nominated = stat;
+          }
+        }
+
+        if (nominated) {
+          const latency = nominated.currentRoundTripTime;
+          const availableBitrate = nominated.availableOutgoingBitrate;
+          const info = `${localStream.getTracks().length} tracks, ${Math.floor(latency / 1000.0)}ms latency` + (
+            availableBitrate ? `, ${Math.floor(availableBitrate / 1024)}kbps available` : "");
+          this._testStep('publish', 'published', info);
+        } else {
+          this._testStep('publish', 'no candidates');
+        }
+
+      };
+
+      this._testStep('subscribe', 'pending');
+
+    });
+
+    window.test_client = this.client = client;
+  };
 
   handleSubmit = e => {
     e.preventDefault();
@@ -62,49 +269,66 @@ class LoginForm extends React.Component {
 
   render() {
     const { getFieldDecorator } = this.props.form;
+    const steps = this.state.steps;
 
     return (
-      <Form onSubmit={this.handleSubmit} className="login-form">
-        <Form.Item>
-          {getFieldDecorator("roomId", {
-            rules: [{ required: true, message: "Please enter your room Id!" }]
-          })(
-            <Input
-              prefix={<Icon type="team" className="login-input-icon" />}
-              placeholder="Room Id"
-            />
-          )}
-        </Form.Item>
-        <Form.Item>
-          {getFieldDecorator("displayName", {
-            rules: [{ required: true, message: "Please enter your Name!" }]
-          })(
-            <Input
-              prefix={
-                <Icon type="contacts" className="login-input-icon" />
-              }
-              placeholder="Display Name"
-            />
-          )}
-        </Form.Item>
-        <Form.Item>
-          {getFieldDecorator('audioOnly', {
-            valuePropName: 'checked',
-            initialValue: true,
-          })(
-            <Checkbox>
-              Audio only
+      <>
+        <Form onSubmit={this.handleSubmit} className="login-form">
+          <Form.Item>
+            {getFieldDecorator("roomId", {
+              rules: [{ required: true, message: "Please enter your room Id!" }]
+            })(
+              <Input
+                prefix={<Icon type="team" className="login-input-icon" />}
+                placeholder="Room Id"
+              />
+            )}
+          </Form.Item>
+          <Form.Item>
+            {getFieldDecorator("displayName", {
+              rules: [{ required: true, message: "Please enter your Name!" }]
+            })(
+              <Input
+                prefix={
+                  <Icon type="contacts" className="login-input-icon" />
+                }
+                placeholder="Display Name"
+              />
+            )}
+          </Form.Item>
+          <Form.Item>
+            {getFieldDecorator('audioOnly', {
+              valuePropName: 'checked',
+              initialValue: true,
+            })(
+              <Checkbox>
+                Audio only
             </Checkbox>
-          )}
-        </Form.Item>
-        <Form.Item>
-          <Button type="primary" htmlType="submit" className="login-join-button">
-            Join
+            )}
+          </Form.Item>
+          <Form.Item>
+            <Button type="primary" htmlType="submit" className="login-join-button">
+              Join
           </Button>
-        </Form.Item>
-      </Form>
+          </Form.Item>
+        </Form>
+        <center>
+          <ConnectionStep step={steps.biz} />
+          <ConnectionStep step={steps.lobby} />
+          <ConnectionStep step={steps.publish} />
+          <ConnectionStep step={steps.subscribe} />
+        </center>
+      </>
     );
   }
+}
+
+function objToStrMap(obj) {
+  const strMap = new Map();
+  for (const k of Object.keys(obj)) {
+    strMap.set(k, obj[k]);
+  }
+  return strMap;
 }
 
 const WrappedLoginForm = Form.create({ name: "login" })(LoginForm);

--- a/styles/css/login.scss
+++ b/styles/css/login.scss
@@ -10,3 +10,11 @@
 .login-join-button {
   width: 100%;
 }
+
+
+.test-connection-step {
+  margin: 1em;
+  width: 3em;
+  vertical-align: top;
+  display: inline-block;
+}


### PR DESCRIPTION
Please help me test this for various failure scenarios, and in various browsers --

+ Tested in Chromium on Linux, seems to work in Firefox too

+ The idea is to simplify debugging `ion` issues down to "How many green checks do you see?"

I'm creating this PR now so I can attach UI screenshots, please don't merge until it's been thoroughly tested.

Successful Connection
===
![image](https://user-images.githubusercontent.com/395107/86689059-80dd5580-bfbb-11ea-8a65-f2950b806dcf.png)

Debug Tooltips
===
![image](https://user-images.githubusercontent.com/395107/86689566-f47f6280-bfbb-11ea-9942-da7a7ac0f7c5.png)


SFU Offline (Biz OK but can't join a room)
===
![image](https://user-images.githubusercontent.com/395107/86689374-c69a1e00-bfbb-11ea-9493-8939e94dd077.png)


