### PR TITLE
fix: The video cannot be displayed as the user enters the room severa…

### DIFF
--- a/src/Conference.jsx
+++ b/src/Conference.jsx
@@ -81,7 +81,7 @@ function Conference(props, ref) {
   const doHandleLocalStream = async (enabled) => {
     const { connector, settings } = props;
     
-    let _streams = streams;
+    let _streams = JSON.parse(JSON.stringify(streams));
     connector.ontrack = (track, stream) => {
       console.log("got track", track.id, "for stream", stream.id);
       if (track.kind === "video") {
@@ -164,12 +164,14 @@ function Conference(props, ref) {
   }
 
   const updateMuteStatus = (stream, muted) => {
-    streams.forEach((item) => {
-      if (item.id == stream.id) {
-        item.muted = muted;
-      }
-    });
-    setStreams(streams)
+    setStreams((p)=>{
+      return p.map(item=>{
+        if (item.id == stream.id) {
+          item.muted = muted;
+        }
+        return item
+      })
+    })
   }
 
   const doHandleScreenSharing = async (enabled) => {


### PR DESCRIPTION
FIX: The video cannot be displayed when the user enters the room several times problem

#### I found that when users entered and left the room multiple times, previous users couldn't properly display the new user's video content.

#### So , Later I found that the common memory problem was caused by reference passing, please refer to the code
