### PR TITLE
Update App.jsx

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -98,7 +98,7 @@ function App(props) {
       window.location.hostname +
       ":" + "5551";
       // Note if you're running this inside docker you'll need to remove the ":5551" and possibly add the following line so that caddy can proxy correctly
-      // + window.location.port;
+      //":" + window.location.port;
     console.log("Connect url:" + url);
     let connector = new Ion.Connector(url, "token");
     setConnector(connector);


### PR DESCRIPTION
Added missing ":" before docker option.

#### Description
Added missing ":" before docker option.

#### Reference issue
Fixes # had me in a loop for a while until I realised that removing ":5551" as the comment suggests leaves the ":" missing from the next line. 

My first ever public Pull request so if this doesn't obey standard practice please be kind. 
